### PR TITLE
Increase ruby version to 2.5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.5-alpine
 LABEL maintainer="Justin Collins <gem@brakeman.org>"
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Hi,

I have applied a fix to the Dockerfile because Docker build is failing since the minimal Ruby version was bumped to 2.5 in commit [04fc780f7a20b7f4e2de8492282b0ce47d8dcdd4](https://github.com/presidentbeef/brakeman/commit/04fc780f7a20b7f4e2de8492282b0ce47d8dcdd4):
```
$ sudo docker build . -t brakeman
Sending build context to Docker daemon  4.149MB
Step 1/11 : FROM ruby:2.4-alpine
2.4-alpine: Pulling from library/ruby
aad63a933944: Pull complete 
cca28d9d22b9: Pull complete 
e46ee7bc75f6: Pull complete 
77f6ac0a75a8: Pull complete 
7d7702b298dc: Pull complete 
Digest: sha256:e81f81a1212ead9850417aaabe9787bafec62d5ecbc93000bd5422ba6042600d
Status: Downloaded newer image for ruby:2.4-alpine
 ---> bcc63e5114c7
Step 2/11 : LABEL maintainer="Justin Collins <gem@brakeman.org>"
 ---> Running in c97cabeae62e
Removing intermediate container c97cabeae62e
 ---> f7e723685c5d
Step 3/11 : WORKDIR /usr/src/app
 ---> Running in 9c50ee5bfb4c
Removing intermediate container 9c50ee5bfb4c
 ---> 5157b862d4ba
Step 4/11 : RUN adduser -u 9000 -D app &&     chown -R app:app /usr/src/app
 ---> Running in 2d832bd08b56
Removing intermediate container 2d832bd08b56
 ---> 9802ac825157
Step 5/11 : USER app
 ---> Running in 207b798d5330
Removing intermediate container 207b798d5330
 ---> 126113236b2e
Step 6/11 : COPY Gemfile* *.gemspec gem_common.rb ./
 ---> cc95e06cfce0
Step 7/11 : COPY lib/brakeman/version.rb ./lib/brakeman/
 ---> 52b586dfd665
Step 8/11 : RUN bundle install --jobs 4 --without "development test"
 ---> Running in dda16e86f73b
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby

    brakeman was resolved to 5.2.1, which depends on
      ruby (>= 2.5.0)

Could not find gem 'ruby (>= 2.5.0)', which is required by gem 'brakeman', in
any of the relevant sources:
  the local ruby installation
The command '/bin/sh -c bundle install --jobs 4 --without "development test"' returned a non-zero code: 6
```

Bumping the version of the ruby image to 2.5 fixes the issue:
```
$ sudo docker build . -t brakeman
Sending build context to Docker daemon  4.149MB
Step 1/11 : FROM ruby:2.5-alpine
2.5-alpine: Pulling from library/ruby
540db60ca938: Already exists 
98a867505730: Pull complete 
69c77620f610: Pull complete 
cd2d3ba0a1da: Pull complete 
cdd230048a01: Pull complete 
Digest: sha256:1aa1dbab746b3dc5d102567a3f91b04023bc61da29bbb36efe1280e9d90074f7
Status: Downloaded newer image for ruby:2.5-alpine
 ---> 67ca994ddbc8
Step 2/11 : LABEL maintainer="Justin Collins <gem@brakeman.org>"
 ---> Running in 3d3392a1d3d8
Removing intermediate container 3d3392a1d3d8
 ---> 710c84969670
Step 3/11 : WORKDIR /usr/src/app
 ---> Running in 3898aff096bf
Removing intermediate container 3898aff096bf
 ---> 8092fadcd94b
Step 4/11 : RUN adduser -u 9000 -D app &&     chown -R app:app /usr/src/app
 ---> Running in d6e91410d738
Removing intermediate container d6e91410d738
 ---> e3301a3250ce
Step 5/11 : USER app
 ---> Running in 4057a709f94c
Removing intermediate container 4057a709f94c
 ---> 6a6c0b00b04b
Step 6/11 : COPY Gemfile* *.gemspec gem_common.rb ./
 ---> ad17a982f39d
Step 7/11 : COPY lib/brakeman/version.rb ./lib/brakeman/
 ---> 51eb7592f541
Step 8/11 : RUN bundle install --jobs 4 --without "development test"
 ---> Running in b28fa4b4958f
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Fetching rake 13.0.6
< removed for brevity >
Use `bundle info [gemname]` to see where a bundled gem is installed.
Removing intermediate container b28fa4b4958f
 ---> 51e7f49a8bef
Step 9/11 : COPY . /usr/src/app
 ---> 34f217debc41
Step 10/11 : WORKDIR /code
 ---> Running in 0207c6410051
Removing intermediate container 0207c6410051
 ---> 905fc39099b6
Step 11/11 : ENTRYPOINT ["/usr/src/app/bin/brakeman"]
 ---> Running in 68a7e444fc73
Removing intermediate container 68a7e444fc73
 ---> b2d8a7d83965
Successfully built b2d8a7d83965
Successfully tagged brakeman:latest
```

Let me know if this is ok.